### PR TITLE
Fix os.swift for Windows

### DIFF
--- a/sources/png/os.swift
+++ b/sources/png/os.swift
@@ -6,11 +6,14 @@
     import Darwin
 #elseif os(Linux)
     import Glibc
+#elseif os(Windows)
+    #warning("Windows in not oficially supported and is untested platform (please open an issue at https://github.com/kelvin13/swift-png/issues)")
+    import ucrt
 #else
     #warning("unsupported or untested platform (please open an issue at https://github.com/kelvin13/swift-png/issues)")
 #endif
 
-#if os(macOS) || os(Linux)
+#if os(macOS) || os(Linux) || os(Windows)
 
 /// enum System 
 ///     A namespace for platform-dependent functionality.
@@ -154,15 +157,25 @@ extension System.File.Source
         {
             return nil 
         }
-        
-        switch status.st_mode & S_IFMT 
+
+#if os(Windows)
+        switch Int32(status.st_mode) & S_IFMT 
         {
-        case S_IFREG, S_IFLNK:
+        case S_IFREG:
             break 
         default:
             return nil 
         }
-        
+#else
+        switch status.st_mode & S_IFMT 
+        {
+        case S_IFREG, S_IFLNK:
+            break
+        default:
+            return nil 
+        }
+#endif
+
         return Int.init(status.st_size)
     } 
 }


### PR DESCRIPTION
With this fix `iphone-optimized` test target could be run with command `swift run -Xswiftc -DNO_INTRINSICS iphone-optimized`.
