### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ swift run -c release compression-test
 
 The `integration-test` product accepts a `-c/--compact` option, which specifies the output verbosity, and an `-e/--print-expected-failures` option, which makes it print the error messages for expected failures.
 
+## Using on Windows
+
+Set `git config --global core.symlinks true` before cloning this repository on Windows.
+
 ## see also 
 
 * [Swift *JPEG*](https://github.com/kelvin13/jpeg)


### PR DESCRIPTION
I would consider this as temporary workaround to solve #35. I would avoid using symlinks completely. What are symlinks used for in this repo could (should) be achieved with using [parameter `sources` of `executableTarget`](https://developer.apple.com/documentation/packagedescription/target/executabletarget(name:dependencies:path:exclude:sources:resources:publicheaderspath:csettings:cxxsettings:swiftsettings:linkersettings:plugins:). For whatever reason I am failing to use `sourses` parameter to get rid of symlinks.